### PR TITLE
ADD repository info to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "sharp-phash",
   "version": "1.1.0",
   "description": "sharp based perceptual hash implementation",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/btd/sharp-phash"
+  },
   "main": "index.js",
   "scripts": {
     "test": "node test.js"


### PR DESCRIPTION
Hi.
I found this great library via npm.
But it was hard to find the github repo, because npm did not link it.
This change adds the repository information to the package.json. On the next release, npm will add this link on the right sidebar.