### PR TITLE
feat: add sharp options

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ function applyDCT(f, size) {
 
 const LOW_SIZE = 8;
 
-module.exports = async function phash(image) {
-  const data = await sharp(image)
+module.exports = async function phash(image, options) {
+  const data = await sharp(image, options)
     .greyscale()
     .resize(SAMPLE_SIZE, SAMPLE_SIZE, { fit: "fill" })
     .rotate()


### PR DESCRIPTION
Related issues: https://github.com/lovell/sharp/issues/2416#issuecomment-714329725

This is a PR that passes sharp options to handle errors from the library.
```ts
const phash = require('sharp-phash');

await phash(img, { failOn: 'none' });
//= await phash(img, { failOnError: false });
```